### PR TITLE
Update rails31 gemfile

### DIFF
--- a/Gemfile-rails31
+++ b/Gemfile-rails31
@@ -13,7 +13,7 @@ group :development do
   gem "sass"
   gem "erubis"
   gem "rdoc", "~>3.4"
-  gem "wrong", ">=0.5.4"
+  gem "wrong", ">=0.6.3"
 end
 
 group :rails do
@@ -25,7 +25,7 @@ group :rails do
   gem 'sass-rails'
   gem 'coffee-script'
   gem 'uglifier'
-
+  gem 'coffee-rails', '~> 3.2.1' 
   gem 'jquery-rails'
   gem 'turn', :require => false
 end

--- a/Gemfile-rails31.lock
+++ b/Gemfile-rails31.lock
@@ -1,12 +1,6 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    ParseTree (3.0.9)
-      RubyInline (~> 3.9.0)
-      sexp_processor (~> 3.2.0)
-    RubyInline (3.9.0)
-      ZenTest (~> 4.3)
-    ZenTest (4.8.2)
     actionmailer (3.2.8)
       actionpack (= 3.2.8)
       mail (~> 2.4.4)
@@ -37,6 +31,9 @@ GEM
     ansi (1.4.3)
     arel (3.0.2)
     builder (3.0.4)
+    coffee-rails (3.2.2)
+      coffee-script (>= 2.2.0)
+      railties (~> 3.2.0)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
@@ -45,8 +42,6 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    file-tail (1.0.12)
-      tins (~> 0.5)
     git (1.2.5)
     haml (3.1.7)
     hike (1.2.1)
@@ -105,11 +100,11 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
-    ruby2ruby (1.3.1)
-      ruby_parser (~> 2.0)
-      sexp_processor (~> 3.0)
-    ruby_parser (2.0.6)
-      sexp_processor (~> 3.0)
+    ruby2ruby (2.0.1)
+      ruby_parser (~> 3.0.0)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.0.4)
+      sexp_processor (~> 4.1)
     rubyforge (2.0.4)
       json_pure (>= 1.1.7)
     sass (3.2.3)
@@ -117,12 +112,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    sexp_processor (3.2.0)
-    sourcify (0.5.0)
-      file-tail (>= 1.0.5)
-      ruby2ruby (>= 1.2.5)
-      ruby_parser (>= 2.0.5)
-      sexp_processor (>= 3.0.5)
+    sexp_processor (4.1.2)
     sprockets (2.1.3)
       hike (~> 1.2)
       rack (~> 1.0)
@@ -130,7 +120,6 @@ GEM
     sqlite3 (1.3.6)
     thor (0.16.0)
     tilt (1.3.3)
-    tins (0.6.0)
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
@@ -140,21 +129,19 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
-    wrong (0.6.0)
-      ParseTree (~> 3.0)
+    wrong (0.7.0)
       diff-lcs (~> 1.1.2)
-      file-tail (~> 1.0)
-      predicated (>= 0.2.3)
-      ruby2ruby (~> 1.2)
-      ruby_parser (~> 2.0.4)
-      sexp_processor (~> 3.0)
-      sourcify (>= 0.3.0)
+      predicated (~> 0.2.6)
+      ruby2ruby (>= 2.0.1)
+      ruby_parser (>= 3.0.1)
+      sexp_processor (>= 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (~> 3)
+  coffee-rails (~> 3.2.1)
   coffee-script
   erubis
   haml
@@ -172,4 +159,4 @@ DEPENDENCIES
   treetop (>= 1.2.3)
   turn
   uglifier
-  wrong (>= 0.5.4)
+  wrong (>= 0.6.3)


### PR DESCRIPTION
- add gem 'wrong', '>=0.6.3'
- add gem 'coffee-rails', '~> 3.2.1'

This allows `rake spec:rails31` to pass
