### PR TITLE
Basic Doctype Helper in Erector::Widgets::Page; XML Declaration stub

### DIFF
--- a/examples/externals_example.rb
+++ b/examples/externals_example.rb
@@ -14,6 +14,9 @@ class HotSauce < Erector::Widget
 end
 
 class HotPage < Erector::Widgets::Page
+  def doctype
+    standard_doctype :html5
+  end
   def body_content
     widget HotSauce
   end

--- a/lib/erector/widgets/page.rb
+++ b/lib/erector/widgets/page.rb
@@ -144,14 +144,14 @@ class Erector::Widgets::Page < Erector::InlineWidget
     standard_doctype(:xhtml10, :transitional)
   end
 
-  # Override to provide XML headers
-  def xml_headers
+  # Override to provide XML declaration. May be nil to indicate that there should not be a declaration.
+  def xml_declaration
     nil
   end
 
   def content
     extra_head_slot = nil
-    xml_head = xml_headers
+    xml_head = xml_declaration
     rawtext(xml_head) if xml_head
     rawtext(doctype)
     html(html_attributes) do

--- a/lib/erector/widgets/page.rb
+++ b/lib/erector/widgets/page.rb
@@ -100,11 +100,48 @@
 #
 class Erector::Widgets::Page < Erector::InlineWidget
 
-  # Emit the Transitional doctype.
-  # TODO: allow selection from among different standard doctypes
+  # Emit the desired doctype. Defaults to HTML5 transitional
+  def standard_doctype(format = :html5, dt = :transitional)
+     inside = case format
+     when :html5, :xhtml5
+        ""
+     when :html4
+        case dt
+        when :transitional
+          'PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd"'
+        when :strict
+          'PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd"'
+        when :frameset
+          'PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd"'
+        end
+     when :xhtml10
+       case dt
+       when :transitional
+         'PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"'
+       when :strict
+         'PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"'
+       when :frameset
+         'PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd"'
+       when :html5
+         ''
+       end
+     when :xhtml11
+       'PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"'
+     when :xhtml20
+       'PUBLIC "-//W3C//DTD XHTML 2.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml2.dtd"'
+     when :basic
+       'PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd"'
+     when :mobile
+       'PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd"'
+     when :rdfa
+       'PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"'
+     end
+     "<!DOCTYPE html#{inside}>"
+  end
+
+  # Override to change the document's doctype
   def doctype
-    '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+    standard_doctype(:xhtml10, :transitional)
   end
 
   def content

--- a/lib/erector/widgets/page.rb
+++ b/lib/erector/widgets/page.rb
@@ -144,9 +144,16 @@ class Erector::Widgets::Page < Erector::InlineWidget
     standard_doctype(:xhtml10, :transitional)
   end
 
+  # Override to provide XML headers
+  def xml_headers
+    nil
+  end
+
   def content
     extra_head_slot = nil
-    rawtext doctype
+    xml_head = xml_headers
+    rawtext(xml_head) if xml_head
+    rawtext(doctype)
     html(html_attributes) do
       head do
         head_content


### PR DESCRIPTION
The helper just makes it easier to find the desired doctype. I also put a comment on the doctype method that indicates that it should be overridden to set the doctype, and set the example application to do so. 

Also, added an XML declaration stub for folks who need them. 
