### PR TITLE
Basic boolean attribute support

### DIFF
--- a/lib/erector/attributes.rb
+++ b/lib/erector/attributes.rb
@@ -17,7 +17,14 @@ module Erector
             next if value.empty?
             value = value.join(' ')
           end
-          results << "#{key}=\"#{h(value)}\""
+          if value.is_a?(TrueClass)
+            # TODO: Consider supporting non-xhtml style, e.g., "<option checked>"
+            results << "#{key}=\"#{key}\""
+          elsif value.is_a?(FalseClass)
+            # Nothing is generated in this case
+          else
+            results << "#{key}=\"#{h(value)}\""
+          end
         end
       end
       results.join(' ')


### PR DESCRIPTION
`attribute="true"` is not strictly supported for boolean attributes.
They should be `attribute="attribute"` or just `attribute`

This commit makes anything that is TrueClass come out as
`attribute="attribute"`, and any `FalseClass` is ignored.

http://www.w3.org/TR/html4/intro/sgmltut.html#h-3.3.4.2
