### PR TITLE
Add hyphenize_underscores option.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+* Add option hyphenize_underscores to control hyphens versus underscores in dot-class and dot-id-bang syntax.
+
 == 0.9.0 - 2012-08-12
 
 * Finally merged bigfix/rails3 branch - Erector now works with either Rails 2 or Rails 3 (or neither)

--- a/lib/erector/abstract_widget.rb
+++ b/lib/erector/abstract_widget.rb
@@ -33,6 +33,16 @@ module Erector
       @@prettyprint_default = enabled
     end
 
+    @@hyphenize_underscores = false
+
+    def self.hyphenize_underscores
+      @@hyphenize_underscores
+    end
+
+    def self.hyphenize_underscores=(enabled)
+      @@hyphenize_underscores = enabled
+    end
+
     def self.inline(*args, &block)
       Class.new(self) do
         include Erector::Inline

--- a/lib/erector/promise.rb
+++ b/lib/erector/promise.rb
@@ -84,6 +84,10 @@ module Erector
 
     def method_missing(method_name, *args, &block)
       method_name = method_name.to_s
+      if Erector::Widget.hyphenize_underscores
+        method_name = method_name.gsub(/_/, "-")
+      end
+
       if method_name =~ /\!$/
         id_str = method_name[0...-1]
         raise ArgumentError, "setting id #{id_str} but id #{@attributes["id"]} already present" if @attributes["id"]

--- a/spec/erector/html_spec.rb
+++ b/spec/erector/html_spec.rb
@@ -77,6 +77,40 @@ describe Erector::HTML do
       end
     end
 
+    context "with underscored attributes" do
+      context "without hyphenize_underscores" do
+        it "keeps class names as underscored" do
+          erector do
+            empty_element('foo').max_thingie
+          end.should == '<foo class="max_thingie" />'
+        end
+
+        it "also keeps classes specified as attributes as underscored" do
+          erector do
+            empty_element('foo', :class => "max_thingie")
+          end.should == '<foo class="max_thingie" />'
+        end
+      end
+
+      context "with hyphenize_underscores" do
+        before do
+          Erector::Widget.hyphenize_underscores = true
+        end
+
+        it "turns underscores in class names into hyphens" do
+          erector do
+            empty_element('foo').max_thingie
+          end.should == '<foo class="max-thingie" />'
+        end
+
+        it "lets you pick underscores or hyphens when specifying a class as an attribute" do
+          erector do
+            empty_element('foo', :class => "max_thingie")
+          end.should == '<foo class="max_thingie" />'
+        end
+      end
+    end
+
     context "with inner tags" do
       it "returns nested tags" do
         erector do

--- a/web/userguide.rb
+++ b/web/userguide.rb
@@ -166,6 +166,75 @@ end
       end
     end
 
+    a.add(:name => "Classes and IDs") do
+      p do
+        text "Because HTML tends to heavily use the "
+        code "class"
+        text " and "
+        code "id"
+        text " attributes, it is convenient to have a special syntax to specify them."
+      end
+      table do
+        tr do
+          td :valign => "top" do
+            source_code :ruby, <<-RUBY
+body.sample!.helpful "Hello, world!"
+            RUBY
+          end
+          td do
+            span.separator do
+              text character(:rightwards_arrow)
+            end
+          end
+          td :valign => "top" do
+            source_code :html, <<-HTML
+body class="helpful" id="sample"
+            HTML
+          end
+        end
+      end
+
+      p do
+        text "Most CSS and javascript tends to write classes and IDs with hyphens (for example "
+        code "nav-bar"
+        text " instead of "
+        code "nav_bar"
+        text "). Therefore, erector has a setting to convert underscores to hyphens."
+      end
+
+      table do
+        tr do
+          td :valign => "top" do
+            source_code :ruby, <<-RUBY
+Erector::Widget.hyphenize_underscores = true
+body.my_id!.nav_bar "Hello, world!"
+            RUBY
+          end
+          td do
+            span.separator do
+              text character(:rightwards_arrow)
+            end
+          end
+          td :valign => "top" do
+            source_code :html, <<-HTML
+body class="nav-bar" id="my-id"
+            HTML
+          end
+        end
+      end
+
+      p do
+        text "You can put the setting of "
+        code "hyphenize_underscores"
+        text " anywhere it is convenient, for example "
+        code "config/application.rb"
+        text " in a rails application. For compatibility with erector 0.9.0, the "
+        text "default is false, but this is likely to change to true in a future version "
+        text "of erector, so explicitly set it to false if you are relying on the "
+        text "underscores."
+      end
+    end
+
 
     a.add(:name => "Erector tool: Command-line conversion to and from HTML", :href => "tool") do
 


### PR DESCRIPTION
Most CSS and javascript (for example, twitter bootstrap) uses hyphens, not underscores, in class names and IDs. This change makes it possible to write something like div.nav_bar and have the class end up as nav-bar not nav_bar. For compatibility with erector 0.9.0, this is an option rather than unconditional, but the patch also changes the documentation to say that the default for the option is likely to change to hyphens in the future.
