### PR TITLE
don't try to duplicate a symbol for needs

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :major: 0
 :minor: 9
-:patch: 0
+:patch: 1

--- a/lib/erector/needs.rb
+++ b/lib/erector/needs.rb
@@ -75,7 +75,7 @@ module Erector
       # set variables with default values
       self.class.needed_defaults.each do |name, value|
         unless assigned.include?(name)
-          value = [NilClass, FalseClass, TrueClass, Fixnum, Float].include?(value.class) ? value : value.dup
+          value = [NilClass, FalseClass, TrueClass, Fixnum, Float, Symbol].include?(value.class) ? value : value.dup
           instance_variable_set("@#{name}", value)
           assigned << name
         end

--- a/spec/erector/needs_spec.rb
+++ b/spec/erector/needs_spec.rb
@@ -99,9 +99,10 @@ describe Erector::Needs do
 
   it "doesn't attempt to dup undupable value if there's another need passed in (bug)" do    
     class Section < Erector::Widget
-      needs :title, :href => nil, :stinky => false, :awesome => true, :answer => 42, :shoe_size => 12.5
+      needs :title, :href => nil, :stinky => false, :awesome => true, :answer => 42, :shoe_size => 12.5, :event_type => :jump
     end    
     Section.new(:title => "Steal Underpants").instance_variable_get(:@awesome).should == true
+    Section.new(:title => "Steal Underpants").instance_variable_get(:@event_type).should == :jump
   end
 
   it "accumulates needs across the inheritance chain even with modules mixed in" do


### PR DESCRIPTION
Having a symbol as a default value would raise the exception 

```
 TypeError:
   can't dup Symbol
```

This patch makes it so it doesn't try to call #dup on a symbol.
