### PR TITLE
ignore_extra_assigns feature where one can skip excess check. 

### DIFF
--- a/lib/erector/needs.rb
+++ b/lib/erector/needs.rb
@@ -65,6 +65,14 @@ module Erector
       def needs?(name)
         needed_variables.empty? || needed_variables.include?(name)
       end
+
+      def ignore_extra_assigns
+        @ignore_extra_assigns ||= false
+      end
+
+      def ignore_extra_assigns=(new_value)
+        @ignore_extra_assigns = (new_value ? :true : :false)
+      end
     end
 
     def initialize(assigns = {})
@@ -87,7 +95,7 @@ module Erector
       end
 
       excess = assigned - self.class.needed_variables
-      unless self.class.needed_variables.empty? || excess.empty?
+      unless self.class.needed_variables.empty? || excess.empty? || self.class.ignore_extra_assigns
         raise ArgumentError, "Excess parameter#{excess.size == 1 ? '' : 's'} for #{self.class.name}: #{excess.join(', ')}"
       end
     end

--- a/spec/erector/needs_spec.rb
+++ b/spec/erector/needs_spec.rb
@@ -137,4 +137,12 @@ describe Erector::Needs do
     end
     lambda { ThingWithOverlap.new(:text => "alas") }.should_not raise_error(ArgumentError)
   end
+
+  it "doesn't complain if you pass it an undeclared parameter and ignore_extra_assigns is set to true" do
+    class ThingIgnoreExtraAssigns < Erector::Widget
+      needs :foo
+    end
+    ThingIgnoreExtraAssigns.ignore_extra_assigns = true
+    lambda { ThingIgnoreExtraAssigns.new(:foo => 1, :bar => 1) }.should_not raise_error(ArgumentError)
+  end
 end


### PR DESCRIPTION
The excess check is driving me nuts :)

What do you think about adding this kind of configuration possibility?

Inspired by :ignore_extra_controller_assigns in rails widget.
As far as i can tell, this is different from how rails widget does :ignore_extra_controller_assigns because it doesn't save the setting if view is inherited. For my use case this is what I need.

What do you think?
