### PR TITLE
Fix FormBuilder for Rails 4.1+

### DIFF
--- a/lib/erector/rails/form_builder.rb
+++ b/lib/erector/rails/form_builder.rb
@@ -13,9 +13,9 @@ module Erector
 
       attr_reader :parent, :template
 
-      def initialize(object_name, object, template, options, proc)
+      def initialize(object_name, object, template, options)
         @template = template
-        @parent = parent_builder_class.new(object_name, object, template, options, proc)
+        @parent = parent_builder_class.new(object_name, object, template, options)
       end
 
       def method_missing(method_name, *args, &block)


### PR DESCRIPTION
Block parameter for FormBuilder was removed in https://github.com/rails/rails/commit/38aafc037705aab2f09ec924bf634d105002e016

Fixes #69.