### PR TITLE
Fix deprecation warnings on Ruby 2.5 and Rails 6

### DIFF
--- a/lib/erector/needs.rb
+++ b/lib/erector/needs.rb
@@ -1,5 +1,7 @@
 module Erector
   module Needs
+    NO_DUP_CLASSES = [NilClass, FalseClass, TrueClass, 0.class, Float, Symbol].freeze
+
     def self.included(base)
       base.extend ClassMethods
     end
@@ -83,7 +85,7 @@ module Erector
       # set variables with default values
       self.class.needed_defaults.each do |name, value|
         unless assigned.include?(name)
-          value = [NilClass, FalseClass, TrueClass, Fixnum, Float, Symbol].include?(value.class) ? value : value.dup
+          value = NO_DUP_CLASSES.include?(value.class) ? value : value.dup
           instance_variable_set("@#{name}", value)
           assigned << name
         end

--- a/lib/erector/rails/template_handler.rb
+++ b/lib/erector/rails/template_handler.rb
@@ -1,7 +1,7 @@
 module Erector
   module Rails
     class TemplateHandler
-      def call(template)
+      def call(template, source = nil)
         require_dependency template.identifier
         widget_class_name = "views/#{template.identifier =~ %r(views/([^.]*)(\..*)?\.rb) && $1}".camelize
         is_partial = File.basename(template.identifier) =~ /^_/


### PR DESCRIPTION
I know this gem isn't actively maintained, but maybe the branch helps somebody that is still using erector in 2019 😄 